### PR TITLE
Add PreviewAnswersScreen example

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,5 @@
-# Ndri
+# Ndri Risk Climate App
+
+This repository now includes a Flutter screen for previewing answers before submission.
+
+The new screen is located at `mobile_app/lib/screens/preview_answers_screen.dart` and allows users to review and edit their responses.

--- a/mobile_app/lib/data/models/question_model.dart
+++ b/mobile_app/lib/data/models/question_model.dart
@@ -1,0 +1,6 @@
+class QuestionModel {
+  final String variableNumber;
+  final String questionText;
+
+  QuestionModel({required this.variableNumber, required this.questionText});
+}

--- a/mobile_app/lib/screens/preview_answers_screen.dart
+++ b/mobile_app/lib/screens/preview_answers_screen.dart
@@ -1,0 +1,80 @@
+import 'package:flutter/material.dart';
+
+import '../../data/models/question_model.dart';
+
+class PreviewAnswersScreen extends StatelessWidget {
+  final Map<String, String> allAnswers;
+  final List<QuestionModel> allQuestions;
+  final Function(String variableNumber) onEdit;
+
+  const PreviewAnswersScreen({
+    Key? key,
+    required this.allAnswers,
+    required this.allQuestions,
+    required this.onEdit,
+  }) : super(key: key);
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(
+        title: const Text('Preview Answers'),
+      ),
+      body: ListView.separated(
+        padding: const EdgeInsets.all(16),
+        itemCount: allQuestions.length,
+        separatorBuilder: (_, __) => const Divider(height: 1),
+        itemBuilder: (context, index) {
+          final question = allQuestions[index];
+          final answer = allAnswers[question.variableNumber] ?? 'Not Answered';
+
+          return Card(
+            margin: const EdgeInsets.symmetric(vertical: 8),
+            child: ListTile(
+              title: Text(
+                '${index + 1}. ${question.questionText}',
+                style: const TextStyle(fontWeight: FontWeight.bold),
+              ),
+              subtitle: Text('Your Answer: $answer'),
+              trailing: IconButton(
+                icon: const Icon(Icons.edit, color: Colors.blue),
+                onPressed: () {
+                  onEdit(question.variableNumber);
+                  Navigator.pop(context);
+                },
+              ),
+            ),
+          );
+        },
+      ),
+      bottomNavigationBar: Padding(
+        padding: const EdgeInsets.all(12.0),
+        child: ElevatedButton(
+          onPressed: () {
+            showDialog(
+              context: context,
+              builder: (context) => AlertDialog(
+                title: const Text('Submit'),
+                content: const Text('Are you sure you want to submit?'),
+                actions: [
+                  TextButton(
+                    onPressed: () => Navigator.pop(context),
+                    child: const Text('Cancel'),
+                  ),
+                  ElevatedButton(
+                    onPressed: () {
+                      Navigator.pop(context);
+                      Navigator.pop(context);
+                    },
+                    child: const Text('Submit'),
+                  ),
+                ],
+              ),
+            );
+          },
+          child: const Text('Submit All Answers'),
+        ),
+      ),
+    );
+  }
+}


### PR DESCRIPTION
## Summary
- add a Flutter screen `PreviewAnswersScreen`
- include simple `QuestionModel` and update README

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_687091e0b2ec8331bc59d1e2d1ab5f1b