### PR TITLE
Fix preview answers

### DIFF
--- a/lib/presentation/screens/preview_answers_screen.dart
+++ b/lib/presentation/screens/preview_answers_screen.dart
@@ -78,7 +78,15 @@ class PreviewAnswersScreen extends StatelessWidget {
             itemBuilder: (context, index) {
               final question = sortedQuestions[index];
               // --- This is the fix: always get answer using variableNumber! ---
-              final answer = allAnswers[question.variableNumber]?.toString() ?? 'Not Answered';
+              final rawAnswer = allAnswers[question.variableNumber]?.toString() ?? 'Not Answered';
+              // Convert stored 1/0 values used for yes/no questions into
+              // human readable booleans. This avoids showing "1" or "0" in
+              // the preview for true/false questions.
+              final answer = rawAnswer == '1'
+                  ? 'True'
+                  : rawAnswer == '0'
+                      ? 'False'
+                      : rawAnswer;
 
               final Color cardColor = (index % 2 == 0)
                   ? Colors.yellow.shade50


### PR DESCRIPTION
## Summary
- fix preview to show boolean answers as True/False

## Testing
- `dart --version` *(fails: command not found)*
- `flutter --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68734f48b5a88331b1069f99891b6281