### PR TITLE
Navigate to disclaimer after submission

### DIFF
--- a/lib/presentation/screens/home_screen.dart
+++ b/lib/presentation/screens/home_screen.dart
@@ -2731,9 +2731,9 @@ class _HomeScreenState extends State<HomeScreen> {
                               });
                             },
                             onSubmit: () {
-                              Navigator.pop(context);
-                              context.read<RiskAssessmentBloc>().add(
-                                  SubmitAnswersEvent());
+                              context.read<RiskAssessmentBloc>()
+                                  .add(SubmitAnswersEvent());
+                              context.go('/disclaimer');
                             },
                           ),
                     ),

--- a/lib/presentation/screens/preview_answers_screen.dart
+++ b/lib/presentation/screens/preview_answers_screen.dart
@@ -310,8 +310,10 @@ class PreviewAnswersScreen extends StatelessWidget {
                 label: "Submit",
                 icon: Icons.check_rounded,
                 onPressed: () async {
-                  await _showSubmitResultDialog(context);
-                  onSubmit();
+                  final didSubmit = await _showSubmitResultDialog(context);
+                  if (didSubmit) {
+                    onSubmit();
+                  }
                 },
                 gradient: const LinearGradient(
                   colors: [
@@ -416,7 +418,7 @@ class _AnimatedButtonState extends State<AnimatedButton>
 }
 
 // --- Submit dialog logic ---
-Future<void> _showSubmitResultDialog(BuildContext context) async {
+Future<bool> _showSubmitResultDialog(BuildContext context) async {
   final shouldSubmit = await showDialog<bool>(
     context: context,
     barrierDismissible: false,
@@ -477,7 +479,7 @@ Future<void> _showSubmitResultDialog(BuildContext context) async {
       ),
     ),
   );
-  if (shouldSubmit != true) return;
+  if (shouldSubmit != true) return false;
   await showDialog(
     context: context,
     barrierDismissible: false,
@@ -614,4 +616,5 @@ Future<void> _showSubmitResultDialog(BuildContext context) async {
       ),
     ),
   );
+  return true;
 }


### PR DESCRIPTION
## Summary
- make preview submission conditional on confirmation
- return bool from preview submission dialog
- after submission, route users back to the disclaimer screen

## Testing
- `flutter --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6874a052af10833189ec51729a95c583