### PR TITLE
Display final score for every question

### DIFF
--- a/lib/presentation/screens/home_screen.dart
+++ b/lib/presentation/screens/home_screen.dart
@@ -3503,7 +3503,12 @@ class _HumanCardState extends State<_HumanCard> {
         setState(() => finalValue = null);
       }
     } else {
-      setState(() => finalValue = null);
+      final double? inputVal = double.tryParse(input);
+      if (inputVal != null) {
+        setState(() => finalValue = 0.0);
+      } else {
+        setState(() => finalValue = null);
+      }
     }
   }
 


### PR DESCRIPTION
## Summary
- compute a `0` final value if a question does not have params
- show final value for each question when input is numeric

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6874ac1bdcc8833182599cde1948a4db