### PR TITLE
Show hazard table in PDF

### DIFF
--- a/lib/data/services/location_service.dart
+++ b/lib/data/services/location_service.dart
@@ -227,4 +227,6 @@ class LocationService {
     _distCache[state] = list;
     return list;
   }
+
+  Map<String, double> get hazardMap => _hazard;
 }

--- a/lib/presentation/screens/home_screen.dart
+++ b/lib/presentation/screens/home_screen.dart
@@ -936,6 +936,28 @@ class _HomeScreenState extends State<HomeScreen> {
       ),
     );
 
+    final hazardEntries = LocationService().hazardMap.entries.toList()
+      ..sort((a, b) => a.key.compareTo(b.key));
+    pdf.addPage(
+      pw.MultiPage(
+        pageFormat: PdfPageFormat.a4,
+        margin: const pw.EdgeInsets.all(20),
+        build: (pw.Context context) {
+          return [
+            pw.Header(level: 0, child: pw.Text('District Hazard Scores')),
+            pw.Table.fromTextArray(
+              headers: ['District', 'Score'],
+              data: [
+                for (final e in hazardEntries)
+                  [e.key, e.value.toStringAsFixed(3)]
+              ],
+              cellAlignment: pw.Alignment.centerLeft,
+            ),
+          ];
+        },
+      ),
+    );
+
     Directory downloadsDir;
     if (Platform.isAndroid) {
       downloadsDir = Directory('/storage/emulated/0/Download');


### PR DESCRIPTION
## Summary
- expose `hazardMap` from `LocationService`
- include hazard table page in generated PDF

## Testing
- `dart format lib/data/services/location_service.dart lib/presentation/screens/home_screen.dart` *(fails: command not found)*


------
https://chatgpt.com/codex/tasks/task_e_687772474f248331a0ea75eeaeed9777