### PR TITLE
Compute operational landholding after sub-question 13.3

### DIFF
--- a/lib/presentation/screens/home_screen.dart
+++ b/lib/presentation/screens/home_screen.dart
@@ -3811,17 +3811,43 @@ class _AgCardState extends State<_AgCard> {
   late TextEditingController _ctrl;
   late Set<String> selP;
   double? finalValue;
+  static final Map<String, String> _landAnswers = {
+    '13.1': '',
+    '13.2': '',
+    '13.3': '',
+  };
 
   @override
   void initState() {
     super.initState();
     _ctrl = TextEditingController(text: widget.savedAnswer ?? '');
-    finalValue = computeFinalValueForInput(
-        widget.question.variableNumber, _ctrl.text);
+    calculateFinalValue(_ctrl.text);
     if (widget.savedAnswer != null && widget.savedAnswer!.isNotEmpty) {
       selP = widget.savedAnswer!.split(',').toSet();
     } else {
       selP = <String>{};
+    }
+  }
+
+  void calculateFinalValue(String input) {
+    final v = widget.question.variableNumber;
+    final bloc = context.read<RiskAssessmentBloc>();
+
+    if (v == '13.1' || v == '13.2' || v == '13.3') {
+      _landAnswers[v] = input;
+
+      final owned = double.tryParse(_landAnswers['13.1'] ?? '') ?? 0.0;
+      final leasedIn = double.tryParse(_landAnswers['13.2'] ?? '') ?? 0.0;
+      final leasedOut = double.tryParse(_landAnswers['13.3'] ?? '') ?? 0.0;
+      final operational = owned + leasedIn - leasedOut;
+
+      bloc.add(SaveAnswerEvent('13', operational.toString()));
+      widget.onSave?.call('13', operational.toString());
+
+      finalValue =
+          v == '13.3' ? computeFinalValueForInput('13', operational.toString()) : null;
+    } else {
+      finalValue = computeFinalValueForInput(v, input);
     }
   }
 
@@ -3978,10 +4004,10 @@ class _AgCardState extends State<_AgCard> {
             ),
             keyboardType: TextInputType.number,
             onChanged: (txt) {
-              setState(() =>
-              finalValue = computeFinalValueForInput(v, txt));
-              context.read<RiskAssessmentBloc>().add(
-                  SaveAnswerEvent(widget.question.variableNumber, txt));
+              setState(() => calculateFinalValue(txt));
+              context
+                  .read<RiskAssessmentBloc>()
+                  .add(SaveAnswerEvent(widget.question.variableNumber, txt));
               widget.onSave?.call(widget.question.variableNumber, txt);
             },
           ),


### PR DESCRIPTION
## Summary
- recalc operational landholding based on 13.1, 13.2 and 13.3
- only show the final weighted value after entering 13.3
- keep latest sub-question values locally to avoid inconsistent results

## Testing
- `flutter --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68777dc2fff48331824bcebf47c4d46e