### PR TITLE
Compute weighted herd size after final sub-question

### DIFF
--- a/lib/logic/score_calculate/question_weight.dart
+++ b/lib/logic/score_calculate/question_weight.dart
@@ -274,9 +274,29 @@ double _calcFor(String key, Map<String, String> ans) {
     input = _parseAnswer('18', ans);
     if (input == 0.0) {
       double sum = 0.0;
-      for (var i = 1; i <= 18; i++) {
-        sum += _parseAnswer('18.$i', ans);
-      }
+      const herdWeights = {
+        '18.1': 1.0,
+        '18.2': 0.8,
+        '18.3': 0.65,
+        '18.4': 0.4,
+        '18.5': 1.0,
+        '18.6': 1.26,
+        '18.7': 1.19,
+        '18.8': 0.85,
+        '18.9': 0.85,
+        '18.10': 0.48,
+        '18.11': 1.19,
+        '18.12': 1.26,
+        '18.13': 1.26,
+        '18.14': 1.01,
+        '18.15': 1.26,
+        '18.16': 0.5,
+        '18.17': 1.26,
+        '18.18': 1.26,
+      };
+      herdWeights.forEach((k, w) {
+        sum += _parseAnswer(k, ans) * w;
+      });
       input = sum;
     }
   }


### PR DESCRIPTION
## Summary
- track herd size sub-question answers
- derive weighted herd size after editing any 18.x field
- store derived herd size under question 18 and show final value only after 18.18
- adjust score calculation to use herd size weights

## Testing
- `flutter --version` *(fails: command not found)*


------
https://chatgpt.com/codex/tasks/task_e_68777dc2fff48331824bcebf47c4d46e