### PR TITLE
Fix gender state and include age in vulnerability

### DIFF
--- a/lib/logic/risk_assessment/bloc/risk_assessment_bloc.dart
+++ b/lib/logic/risk_assessment/bloc/risk_assessment_bloc.dart
@@ -65,7 +65,7 @@ class RiskAssessmentBloc extends Bloc<RiskAssessmentEvent, RiskAssessmentState> 
           questions: state.questions,
           answers: updatedAnswers,
           name: state.name,
-          gender: event.questionNumber == 2 ? event.answer : state.gender,
+          gender: event.questionNumber == '1' ? event.answer : state.gender,
           stateName: state.stateName,
           district: state.district,
           block: state.block,

--- a/lib/logic/score_calculate/question_weight.dart
+++ b/lib/logic/score_calculate/question_weight.dart
@@ -245,7 +245,7 @@ int mapHouseType(String val) {
 
 // Keys for vulnerability and exposure questions used in score calculation
 final Set<String> vulnerabilityKeys = {
-  '13', '15', '18', '18.1', '18.8', '18.14', '28', '26'
+  '2', '13', '15', '18', '18.1', '18.8', '18.14', '28', '26'
 };
 
 final Set<String> exposureKeys = {


### PR DESCRIPTION
## Summary
- treat the first question as the gender field when saving answers
- include Age question in vulnerability score calculation

## Testing
- `flutter --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6877901153888331987e048bfb6707c4