### PR TITLE
Handle dropdown inputs for score computation

### DIFF
--- a/lib/logic/score_calculate/question_weight.dart
+++ b/lib/logic/score_calculate/question_weight.dart
@@ -257,7 +257,16 @@ final Set<String> exposureKeys = {
 double _parseAnswer(String key, Map<String, String> ans) {
   String? raw = ans[key];
   if (raw == null || raw.isEmpty) return 0.0;
-  return double.tryParse(raw) ?? 0.0;
+  final parsed = double.tryParse(raw);
+  if (parsed != null) return parsed;
+  if (key == '3') {
+    final idx = mapEducation(raw);
+    return idx < 0 ? 0.0 : idx.toDouble();
+  }
+  if (key == '10') {
+    return mapHouseType(raw).toDouble();
+  }
+  return 0.0;
 }
 
 double _calcFor(String key, Map<String, String> ans) {
@@ -329,8 +338,18 @@ double computeExposureScore(Map<String, String> ans) =>
     computeScore(ans, exposureKeys);
 
 double? computeFinalValueForInput(String key, String input) {
-  final double? val = double.tryParse(input);
-  if (val == null) return null;
+  double? val = double.tryParse(input);
+  if (val == null) {
+    if (key == '3') {
+      final idx = mapEducation(input);
+      if (idx == -1) return null;
+      val = idx.toDouble();
+    } else if (key == '10') {
+      val = mapHouseType(input).toDouble();
+    } else {
+      return null;
+    }
+  }
   if (questionParams.containsKey(key)) {
     final p = questionParams[key]!;
     final min = p['min'] as num;

--- a/lib/presentation/screens/home_screen.dart
+++ b/lib/presentation/screens/home_screen.dart
@@ -3661,6 +3661,7 @@ class _HumanCardState extends State<_HumanCard> {
             setState(() => _edu = val);
             context.read<RiskAssessmentBloc>().add(SaveAnswerEvent(v, val!));
             widget.onSave?.call(v, val);
+            calculateFinalValue(val);
           },
         ),
       );
@@ -3681,6 +3682,7 @@ class _HumanCardState extends State<_HumanCard> {
             setState(() => _household = val);
             context.read<RiskAssessmentBloc>().add(SaveAnswerEvent(v, val!));
             widget.onSave?.call(v, val);
+            calculateFinalValue(val);
           },
         ),
       );


### PR DESCRIPTION
## Summary
- parse dropdown answers for education and household type
- show final value when changing these dropdowns

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_687793d0c9c48331a945fcd08611b4ee