### PR TITLE
Add weight params for questions 12, 16 and 17

### DIFF
--- a/lib/logic/score_calculate/question_weight.dart
+++ b/lib/logic/score_calculate/question_weight.dart
@@ -59,6 +59,12 @@ final Map<String, Map<String, dynamic>> questionParams  = {
     'weight': 2.839466072,
     'isPositive': false,
   },
+  '12': {
+    'min': 15,
+    'max': 73,
+    'weight': 2.839466072,
+    'isPositive': false,
+  },
   '13': {
     'min': 0,
     'max': 67,
@@ -87,6 +93,18 @@ final Map<String, Map<String, dynamic>> questionParams  = {
     'min': 0,
     'max': 67,
     'weight': 7.8191,
+    'isPositive': false,
+  },
+  '16': {
+    'min': 5.18,
+    'max': 40,
+    'weight': 5.284811166,
+    'isPositive': false,
+  },
+  '17': {
+    'min': 4,
+    'max': 32.5,
+    'weight': 3.789836569,
     'isPositive': false,
   },
   '18': {


### PR DESCRIPTION
## Summary
- extend question scoring with weights for questions 12, 16 and 17
- keep existing weights for other questions

## Testing
- `dart format lib/logic/score_calculate/question_weight.dart` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6877ce204fb4833195de03f3f733a387