### PR TITLE
Add years of schooling input for education question

### DIFF
--- a/lib/logic/score_calculate/question_weight.dart
+++ b/lib/logic/score_calculate/question_weight.dart
@@ -7,9 +7,9 @@ final Map<String, Map<String, dynamic>> questionParams  = {
   },
   '3': {
     'min': 0,
-    'max': 6,
-    'weight': 0.2,
-    'isPositive': true,
+    'max': 21,
+    'weight': 2.629222072,
+    'isPositive': false,
   },
   '4': {
     'min': 1,
@@ -283,10 +283,6 @@ double _parseAnswer(String key, Map<String, String> ans) {
   if (raw == null || raw.isEmpty) return 0.0;
   final parsed = double.tryParse(raw);
   if (parsed != null) return parsed;
-  if (key == '3') {
-    final idx = mapEducation(raw);
-    return idx < 0 ? 0.0 : idx.toDouble();
-  }
   if (key == '10') {
     return mapHouseType(raw).toDouble();
   }
@@ -364,11 +360,7 @@ double computeExposureScore(Map<String, String> ans) =>
 double? computeFinalValueForInput(String key, String input) {
   double? val = double.tryParse(input);
   if (val == null) {
-    if (key == '3') {
-      final idx = mapEducation(input);
-      if (idx == -1) return null;
-      val = idx.toDouble();
-    } else if (key == '10') {
+    if (key == '10') {
       val = mapHouseType(input).toDouble();
     } else {
       return null;

--- a/lib/presentation/screens/home_screen.dart
+++ b/lib/presentation/screens/home_screen.dart
@@ -1701,6 +1701,9 @@ class _HomeScreenState extends State<HomeScreen> {
                   child: _HumanCard(
                     question: qs[idx],
                     savedAnswer: _getSavedAnswer(qs[idx].variableNumber),
+                    savedEdu: qs[idx].variableNumber == '3'
+                        ? _getSavedAnswer('3_level')
+                        : null,
                     onGenderSelected: (val) {
                       setState(() => _selectedGender = val);
                       _saveFieldAnswers();
@@ -3568,12 +3571,14 @@ class _HomeScreenState extends State<HomeScreen> {
 class _HumanCard extends StatefulWidget {
   final QuestionModel question;
   final String? savedAnswer;
+  final String? savedEdu;
   final void Function(String)? onGenderSelected;
   final Future<void> Function(String, dynamic)? onSave;
 
   const _HumanCard({
     required this.question,
     this.savedAnswer,
+    this.savedEdu,
     this.onGenderSelected,
     this.onSave,
   });
@@ -3592,7 +3597,7 @@ class _HumanCardState extends State<_HumanCard> {
     super.initState();
     final v = widget.question.variableNumber;
     if (v == '1') _gender = widget.savedAnswer;
-    if (v == '3') _edu = widget.savedAnswer;
+    if (v == '3') _edu = widget.savedEdu;
     if (v == '10') _household = widget.savedAnswer;
     _ctrl = TextEditingController(text: widget.savedAnswer ?? '');
     calculateFinalValue(_ctrl.text);
@@ -3619,6 +3624,7 @@ class _HumanCardState extends State<_HumanCard> {
         : AppColors.greenColor;
 
     Widget field;
+    Widget? extraField;
     if (v == '1') {
       field = DropdownButtonHideUnderline(
         child: DropdownButton<String>(
@@ -3653,18 +3659,69 @@ class _HumanCardState extends State<_HumanCard> {
             'Diploma/certificate course',
             'Graduate',
             'Post graduate and above',
-          ].map((e) =>
-              DropdownMenuItem(
+          ]
+              .map((e) => DropdownMenuItem(
                   value: e, child: Text(e, overflow: TextOverflow.ellipsis)))
               .toList(),
           onChanged: (val) {
             setState(() => _edu = val);
-            context.read<RiskAssessmentBloc>().add(SaveAnswerEvent(v, val!));
-            widget.onSave?.call(v, val);
-            calculateFinalValue(val);
+            if (val != null) {
+              context
+                  .read<RiskAssessmentBloc>()
+                  .add(SaveAnswerEvent('${v}_level', val));
+              widget.onSave?.call('${v}_level', val);
+            }
           },
         ),
       );
+      if (_edu != null) {
+        extraField = Column(
+          crossAxisAlignment: CrossAxisAlignment.stretch,
+          children: [
+            Container(
+              padding: EdgeInsets.symmetric(horizontal: 8.w, vertical: 6.h),
+              decoration: BoxDecoration(
+                  color: barCol,
+                  border: Border.all(color: Colors.black, width: 1.5)),
+              child: AppText(
+                  text: 'Number of years of schooling',
+                  color: barCol == AppColors.yellowColor
+                      ? Colors.black
+                      : Colors.white,
+                  textSize: 14.sp,
+                  fontWeight: FontWeight.w600),
+            ),
+            Container(
+              height: 38.h,
+              margin: EdgeInsets.only(bottom: 6.h),
+              decoration: BoxDecoration(
+                  color: Colors.white,
+                  border: Border.all(color: AppColors.greenColor, width: 1.4)),
+              padding: EdgeInsets.symmetric(horizontal: 8.w),
+              alignment: Alignment.centerLeft,
+              child: TextField(
+                controller: _ctrl,
+                textAlignVertical: TextAlignVertical.center,
+                decoration: InputDecoration(
+                  border: InputBorder.none,
+                  isDense: true,
+                  hintText: 'Years',
+                  hintStyle: const TextStyle(color: Colors.grey),
+                  contentPadding: EdgeInsets.symmetric(vertical: 3.h),
+                ),
+                keyboardType: TextInputType.number,
+                onChanged: (txt) {
+                  calculateFinalValue(txt);
+                  context
+                      .read<RiskAssessmentBloc>()
+                      .add(SaveAnswerEvent(v, txt));
+                  widget.onSave?.call(v, txt);
+                },
+              ),
+            ),
+          ],
+        );
+      }
     } else if (v == '10') {
       field = DropdownButtonHideUnderline(
         child: DropdownButton<String>(
@@ -3706,35 +3763,36 @@ class _HumanCardState extends State<_HumanCard> {
       );
     }
 
-    return Column(
-      crossAxisAlignment: CrossAxisAlignment.stretch,
-      children: [
-        Container(
-          padding: EdgeInsets.symmetric(horizontal: 8.w, vertical: 6.h),
-          decoration: BoxDecoration(
-              color: barCol,
-              border: Border.all(color: Colors.black, width: 1.5)),
-          child: AppText(
+      return Column(
+        crossAxisAlignment: CrossAxisAlignment.stretch,
+        children: [
+          Container(
+            padding: EdgeInsets.symmetric(horizontal: 8.w, vertical: 6.h),
+            decoration: BoxDecoration(
+                color: barCol,
+                border: Border.all(color: Colors.black, width: 1.5)),
+            child: AppText(
               text: '$v. ${widget.question.questionText}',
               color: barCol == AppColors.yellowColor ? Colors.black : Colors
                   .white,
               textSize: 14.sp,
               fontWeight: FontWeight.w600),
         ),
-        Container(
-          height: 38.h,
-          margin: EdgeInsets.only(bottom: 6.h),
-          decoration: BoxDecoration(
-              color: Colors.white,
-              border: Border.all(color: AppColors.greenColor, width: 1.4)),
-          padding: EdgeInsets.symmetric(horizontal: 8.w),
-          alignment: Alignment.centerLeft,
-          child: field,
-        ),
-        if (finalValue != null)
-          Padding(
-            padding: EdgeInsets.only(bottom: 14.h, left: 8.w),
-            child: Text(
+          Container(
+            height: 38.h,
+            margin: EdgeInsets.only(bottom: 6.h),
+            decoration: BoxDecoration(
+                color: Colors.white,
+                border: Border.all(color: AppColors.greenColor, width: 1.4)),
+            padding: EdgeInsets.symmetric(horizontal: 8.w),
+            alignment: Alignment.centerLeft,
+            child: field,
+          ),
+          if (extraField != null) extraField!,
+          if (finalValue != null)
+            Padding(
+              padding: EdgeInsets.only(bottom: 14.h, left: 8.w),
+              child: Text(
               'Final Value: ${finalValue!.toStringAsFixed(3)}',
               style: TextStyle(
                 color: Colors.teal.shade700,


### PR DESCRIPTION
## Summary
- add numeric years of schooling field for question 3
- update question 3 weight parameters
- compute education score using numeric input
- persist selected education level and hide years input until a choice is made

## Testing
- `flutter --version` *(fails: command not found)*
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6878c8a4686483318be0da71cd07bee3