### PR TITLE
Update weight formulas for questions 8‑10

### DIFF
--- a/lib/logic/score_calculate/question_weight.dart
+++ b/lib/logic/score_calculate/question_weight.dart
@@ -37,8 +37,8 @@ final Map<String, Map<String, dynamic>> questionParams  = {
   },
   '8': {
     'min': 0,
-    'max': 12,
-    'weight': 2.652984683,
+    'max': 4,
+    'weight': 2.040972142,
     'isPositive': true,
   },
   '9': {
@@ -48,9 +48,9 @@ final Map<String, Map<String, dynamic>> questionParams  = {
     'isPositive': true,
   },
   '10': {
-    'min': 0,
-    'max': 2,
-    'weight': 0.08,
+    'min': 1,
+    'max': 3,
+    'weight': 3.898970878,
     'isPositive': false,
   },
   '11': {
@@ -159,7 +159,7 @@ final Map<String, Map<String, dynamic>> questionParams  = {
   '8_exp': {
     'min': 0,
     'max': 4,
-    'weight': 2.0410,
+    'weight': 2.040972142,
     'isPositive': true,
   },
   '6_exp': {
@@ -177,7 +177,7 @@ final Map<String, Map<String, dynamic>> questionParams  = {
   '9_exp': {
     'min': 0,
     'max': 3,
-    'weight': 1.9701,
+    'weight': 1.970125947,
     'isPositive': true,
   },
   '19_exp': {
@@ -207,7 +207,7 @@ final Map<String, Map<String, dynamic>> questionParams  = {
   '10_exp': {
     'min': 1,
     'max': 3,
-    'weight': 3.8990,
+    'weight': 3.898970878,
     'isPositive': false,
   },
   '23_exp': {
@@ -262,9 +262,9 @@ int mapEducation(String val) {
 }
 
 int mapHouseType(String val) {
-  if (val == 'Permanent Pucca house') return 0;
-  if (val == 'Permanent Kaccha house') return 1;
-  return 2;
+  if (val == 'Permanent Pucca house') return 1;
+  if (val == 'Permanent Kaccha house') return 2;
+  return 3;
 }
 
 // Keys for vulnerability and exposure questions used in score calculation


### PR DESCRIPTION
## Summary
- update question parameters for questions 8, 9 and 10
- adjust exposure counterparts to same weights
- change `mapHouseType` to use 1‑based values

## Testing
- `flutter --version` *(fails: command not found)*
- `dart analyze` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6878e35070788331b64213c12ef01025