### PR TITLE
Update exposure weights

### DIFF
--- a/lib/logic/score_calculate/question_weight.dart
+++ b/lib/logic/score_calculate/question_weight.dart
@@ -213,37 +213,37 @@ final Map<String, Map<String, dynamic>> questionParams  = {
   '23_exp': {
     'min': 0,
     'max': 20,
-    'weight': 3.073021933,
+    'weight': 3.07302,
     'isPositive': false,
   },
   '24_exp': {
     'min': 0.5,
     'max': 20,
-    'weight': 3.261928395,
+    'weight': 3.26193,
     'isPositive': false,
   },
   '25_exp': {
     'min': 0,
     'max': 30,
-    'weight': 4.714729009,
+    'weight': 4.71473,
     'isPositive': false,
   },
   '26_exp': {
     'min': 0.5,
     'max': 40,
-    'weight': 4.537967284,
+    'weight': 4.53797,
     'isPositive': false,
   },
   '21_exp': {
     'min': 0.5,
     'max': 25,
-    'weight': 4.399515629,
+    'weight': 4.39952,
     'isPositive': false,
   },
   '22_exp': {
     'min': 0.5,
     'max': 26,
-    'weight': 4.605965244,
+    'weight': 4.60597,
     'isPositive': false,
   },
 };


### PR DESCRIPTION
## Summary
- tweak exposure parameter weights for questions 21 to 26

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6878ed2c70b48331962dda8e9cc41b8b