### PR TITLE
Display accepted values for questions

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,3 +3,9 @@
 This repository now includes a Flutter screen for previewing answers before submission.
 
 The new screen is located at `mobile_app/lib/screens/preview_answers_screen.dart` and allows users to review and edit their responses.
+
+## Accepted Values
+
+Each question now stores a `finalValue`. An additional `acceptedValue` is derived
+from this. If the `finalValue` is negative, `acceptedValue` defaults to `0`.
+Both values are displayed on the preview screen.

--- a/mobile_app/lib/data/models/question_model.dart
+++ b/mobile_app/lib/data/models/question_model.dart
@@ -1,6 +1,15 @@
 class QuestionModel {
   final String variableNumber;
   final String questionText;
+  final double finalValue;
 
-  QuestionModel({required this.variableNumber, required this.questionText});
+  QuestionModel({
+    required this.variableNumber,
+    required this.questionText,
+    required this.finalValue,
+  });
+
+  /// Accepted value for the question. If [finalValue] is negative,
+  /// this returns `0`, otherwise it returns [finalValue].
+  double get acceptedValue => finalValue < 0 ? 0 : finalValue;
 }

--- a/mobile_app/lib/screens/preview_answers_screen.dart
+++ b/mobile_app/lib/screens/preview_answers_screen.dart
@@ -35,7 +35,14 @@ class PreviewAnswersScreen extends StatelessWidget {
                 '${index + 1}. ${question.questionText}',
                 style: const TextStyle(fontWeight: FontWeight.bold),
               ),
-              subtitle: Text('Your Answer: $answer'),
+              subtitle: Column(
+                crossAxisAlignment: CrossAxisAlignment.start,
+                children: [
+                  Text('Your Answer: $answer'),
+                  Text('Final Value: ${question.finalValue}'),
+                  Text('Accepted Value: ${question.acceptedValue}'),
+                ],
+              ),
               trailing: IconButton(
                 icon: const Icon(Icons.edit, color: Colors.blue),
                 onPressed: () {


### PR DESCRIPTION
## Summary
- add `finalValue` and `acceptedValue` to `QuestionModel`
- display final and accepted values on the preview screen
- document accepted value behaviour in README

## Testing
- `flutter --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_687c548a11b48331b3d1eb40404b6433