### PR TITLE
Add scoring support for disease profile question

### DIFF
--- a/lib/logic/score_calculate/question_weight.dart
+++ b/lib/logic/score_calculate/question_weight.dart
@@ -137,6 +137,12 @@ final Map<String, Map<String, dynamic>> questionParams  = {
     'weight': 1.592305378,
     'isPositive': true,
   },
+  '20': {
+    'min': 0,
+    'max': 5,
+    'weight': 1.352507861,
+    'isPositive': true,
+  },
   '28': {
     'min': 0,
     'max': 36,
@@ -364,6 +370,12 @@ double? computeFinalValueForInput(String key, String input) {
   if (val == null) {
     if (key == '10') {
       val = mapHouseType(input).toDouble();
+    } else if (key == '20') {
+      if (input.trim().isEmpty) {
+        val = 0;
+      } else {
+        val = input.split(',').where((e) => e.trim().isNotEmpty).length.toDouble();
+      }
     } else {
       return null;
     }


### PR DESCRIPTION
## Summary
- assign weights for question 20 (disease profile)
- parse multi-select values so question 20 can compute a final value

## Testing
- `dart format lib/logic/score_calculate/question_weight.dart` *(fails: command not found)*
- `flutter --version` *(fails: command not found)*
- `sudo apt-get update` *(fails: repository signatures could not be verified)*

------
https://chatgpt.com/codex/tasks/task_e_687f29d2313c833180fc278864ab6175