### PR TITLE
Fix realtime update for question 20

### DIFF
--- a/lib/logic/score_calculate/question_weight.dart
+++ b/lib/logic/score_calculate/question_weight.dart
@@ -143,6 +143,18 @@ final Map<String, Map<String, dynamic>> questionParams  = {
     'weight': 1.352507861,
     'isPositive': true,
   },
+  '21': {
+    'min': 0.5,
+    'max': 25,
+    'weight': 4.399515629,
+    'isPositive': false,
+  },
+  '22': {
+    'min': 0.5,
+    'max': 26,
+    'weight': 4.605965244,
+    'isPositive': false,
+  },
   '28': {
     'min': 0,
     'max': 36,

--- a/lib/presentation/screens/home_screen.dart
+++ b/lib/presentation/screens/home_screen.dart
@@ -4205,7 +4205,10 @@ class _AgCardState extends State<_AgCard> {
                                   padding: const EdgeInsets.only(right: 8),
                                   child: GestureDetector(
                                     onTap: () {
-                                      setState(() => selP.remove(d));
+                                      setState(() {
+                                        selP.remove(d);
+                                        finalValue = computeFinalValueForInput('20', selP.join(','));
+                                      });
                                       context
                                           .read<RiskAssessmentBloc>()
                                           .add(SaveAnswerEvent(
@@ -4230,7 +4233,10 @@ class _AgCardState extends State<_AgCard> {
                                           size: 16,
                                           color: Colors.green.shade700),
                                       onDeleted: () {
-                                        setState(() => selP.remove(d));
+                                        setState(() {
+                                          selP.remove(d);
+                                          finalValue = computeFinalValueForInput('20', selP.join(','));
+                                        });
                                         context
                                             .read<RiskAssessmentBloc>()
                                             .add(SaveAnswerEvent(
@@ -4283,8 +4289,10 @@ class _AgCardState extends State<_AgCard> {
                     final bool selected = selP.contains(label);
                     return GestureDetector(
                       onTap: () {
-                        setState(() =>
-                        selected ? selP.remove(label) : selP.add(label));
+                        setState(() {
+                          selected ? selP.remove(label) : selP.add(label);
+                          finalValue = computeFinalValueForInput('20', selP.join(','));
+                        });
                         context
                             .read<RiskAssessmentBloc>()
                             .add(SaveAnswerEvent('20', selP.join(',')));


### PR DESCRIPTION
## Summary
- fix realtime update of final value for question 20
- add weight parameters for questions 21 and 22

## Testing
- `dart format lib/logic/score_calculate/question_weight.dart lib/presentation/screens/home_screen.dart` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_687f2c55db18833192b5ffee39e21483