### PR TITLE
Update milk sale and consumption parameters

### DIFF
--- a/lib/logic/score_calculate/question_weight.dart
+++ b/lib/logic/score_calculate/question_weight.dart
@@ -179,10 +179,16 @@ final Map<String, Map<String, dynamic>> questionParams  = {
     'weight': 4.537967284,
     'isPositive': false,
   },
+  '27': {
+    'min': 0,
+    'max': 140,
+    'weight': 4.483170892,
+    'isPositive': false,
+  },
   '28': {
     'min': 0,
     'max': 36,
-    'weight': 5.7398,
+    'weight': 5.739753618,
     'isPositive': false,
   },
   // Exposure indicators


### PR DESCRIPTION
## Summary
- add scoring parameters for question 27 (Amount of milk sold)
- update question 28 weight to precise value

## Testing
- `dart format lib/logic/score_calculate/question_weight.dart` *(fails: command not found)*
- `flutter format lib/logic/score_calculate/question_weight.dart` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_687f3312ac40833187bf3e977d9b30f2