### PR TITLE
Add parameters for questions 34 and 35

### DIFF
--- a/lib/logic/score_calculate/question_weight.dart
+++ b/lib/logic/score_calculate/question_weight.dart
@@ -191,6 +191,18 @@ final Map<String, Map<String, dynamic>> questionParams  = {
     'weight': 5.739753618,
     'isPositive': false,
   },
+  '34': {
+    'min': 0,
+    'max': 1,
+    'weight': 1.592334687,
+    'isPositive': true,
+  },
+  '35': {
+    'min': 0,
+    'max': 50,
+    'weight': 3.87279524,
+    'isPositive': false,
+  },
   // Exposure indicators
   '7_exp': {
     'min': 0,


### PR DESCRIPTION
## Summary
- add new question parameters for items 34 and 35 used for computing vulnerability values

## Testing
- `flutter --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_687f3aeba8648331b8f84fa3d12c9fbe