### PR TITLE
Implement income from agriculture calculation

### DIFF
--- a/lib/logic/score_calculate/question_weight.dart
+++ b/lib/logic/score_calculate/question_weight.dart
@@ -191,6 +191,12 @@ final Map<String, Map<String, dynamic>> questionParams  = {
     'weight': 5.739753618,
     'isPositive': false,
   },
+  '31': {
+    'min': 0,
+    'max': 5885600,
+    'weight': 7.779105961,
+    'isPositive': false,
+  },
   '34': {
     'min': 0,
     'max': 1,
@@ -430,6 +436,10 @@ double _calcFor(String key, Map<String, String> ans) {
       });
       input = sum;
     }
+  } else if (key == '31') {
+    final total = _parseAnswer('30', ans);
+    final percent = _parseAnswer('31', ans);
+    input = total * percent / 100.0;
   }
   final min = p['min'] as num;
   final max = p['max'] as num;

--- a/lib/presentation/screens/home_screen.dart
+++ b/lib/presentation/screens/home_screen.dart
@@ -4711,8 +4711,16 @@ class _LivCardState extends State<_LivCard> {
   void initState() {
     super.initState();
     _ctrl = TextEditingController(text: widget.savedAnswer ?? '');
-    finalValue = computeFinalValueForInput(
-        widget.question.variableNumber, _ctrl.text);
+    final v = widget.question.variableNumber;
+    if (v == '31') {
+      final ans = context.read<RiskAssessmentBloc>().state.answers['30'];
+      final total = double.tryParse(ans ?? '') ?? 0.0;
+      final perc = double.tryParse(_ctrl.text) ?? 0.0;
+      final computed = total * perc / 100.0;
+      finalValue = computeFinalValueForInput('31', computed.toString());
+    } else {
+      finalValue = computeFinalValueForInput(v, _ctrl.text);
+    }
   }
 
   @override
@@ -4758,8 +4766,17 @@ class _LivCardState extends State<_LivCard> {
           ),
           keyboardType: TextInputType.number,
           onChanged: (txt) {
-            setState(() =>
-            finalValue = computeFinalValueForInput(v, txt));
+            setState(() {
+              if (v == '31') {
+                final ans = context.read<RiskAssessmentBloc>().state.answers['30'];
+                final total = double.tryParse(ans ?? '') ?? 0.0;
+                final perc = double.tryParse(txt) ?? 0.0;
+                final computed = total * perc / 100.0;
+                finalValue = computeFinalValueForInput('31', computed.toString());
+              } else {
+                finalValue = computeFinalValueForInput(v, txt);
+              }
+            });
             context
                 .read<RiskAssessmentBloc>()
                 .add(SaveAnswerEvent(widget.question.variableNumber, txt));


### PR DESCRIPTION
## Summary
- add question parameters and scoring logic for variable 31
- compute derived value from question 30 for income from agriculture
- update `_LivCard` widget to use new computation

## Testing
- `flutter` command not available so no tests were run

------
https://chatgpt.com/codex/tasks/task_e_688066494ab4833198edd3dffa85e92c