### PR TITLE
Add dairy & other income scoring

### DIFF
--- a/lib/logic/score_calculate/question_weight.dart
+++ b/lib/logic/score_calculate/question_weight.dart
@@ -197,6 +197,18 @@ final Map<String, Map<String, dynamic>> questionParams  = {
     'weight': 7.779105961,
     'isPositive': false,
   },
+  '32': {
+    'min': 0,
+    'max': 3628800,
+    'weight': 5.11020067554158,
+    'isPositive': false,
+  },
+  '33': {
+    'min': 0,
+    'max': 234900,
+    'weight': 3.098447705,
+    'isPositive': false,
+  },
   '34': {
     'min': 0,
     'max': 1,
@@ -439,6 +451,14 @@ double _calcFor(String key, Map<String, String> ans) {
   } else if (key == '31') {
     final total = _parseAnswer('30', ans);
     final percent = _parseAnswer('31', ans);
+    input = total * percent / 100.0;
+  } else if (key == '32') {
+    final total = _parseAnswer('30', ans);
+    final percent = _parseAnswer('32', ans);
+    input = total * percent / 100.0;
+  } else if (key == '33') {
+    final total = _parseAnswer('30', ans);
+    final percent = _parseAnswer('33', ans);
     input = total * percent / 100.0;
   }
   final min = p['min'] as num;

--- a/lib/presentation/screens/home_screen.dart
+++ b/lib/presentation/screens/home_screen.dart
@@ -4712,12 +4712,12 @@ class _LivCardState extends State<_LivCard> {
     super.initState();
     _ctrl = TextEditingController(text: widget.savedAnswer ?? '');
     final v = widget.question.variableNumber;
-    if (v == '31') {
+    if (v == '31' || v == '32' || v == '33') {
       final ans = context.read<RiskAssessmentBloc>().state.answers['30'];
       final total = double.tryParse(ans ?? '') ?? 0.0;
       final perc = double.tryParse(_ctrl.text) ?? 0.0;
       final computed = total * perc / 100.0;
-      finalValue = computeFinalValueForInput('31', computed.toString());
+      finalValue = computeFinalValueForInput(v, computed.toString());
     } else {
       finalValue = computeFinalValueForInput(v, _ctrl.text);
     }
@@ -4767,12 +4767,12 @@ class _LivCardState extends State<_LivCard> {
           keyboardType: TextInputType.number,
           onChanged: (txt) {
             setState(() {
-              if (v == '31') {
+              if (v == '31' || v == '32' || v == '33') {
                 final ans = context.read<RiskAssessmentBloc>().state.answers['30'];
                 final total = double.tryParse(ans ?? '') ?? 0.0;
                 final perc = double.tryParse(txt) ?? 0.0;
                 final computed = total * perc / 100.0;
-                finalValue = computeFinalValueForInput('31', computed.toString());
+                finalValue = computeFinalValueForInput(v, computed.toString());
               } else {
                 finalValue = computeFinalValueForInput(v, txt);
               }


### PR DESCRIPTION
## Summary
- add scoring parameters for questions 32 and 33
- compute derived income values for questions 32 and 33
- update LiveCard to handle questions 32 and 33

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68806b4880a483318fcd62bcc91320de