### PR TITLE
Add exposure detail logging

### DIFF
--- a/lib/logic/score_calculate/question_weight.dart
+++ b/lib/logic/score_calculate/question_weight.dart
@@ -491,6 +491,22 @@ double computeVulnerabilityScore(Map<String, String> ans) =>
 double computeExposureScore(Map<String, String> ans) =>
     computeScore(ans, exposureKeys);
 
+/// Returns a map containing the raw sum of weighted exposure values,
+/// the total weight of all exposure questions and the final exposure
+/// score (sum divided by total weight).
+Map<String, double> computeExposureDetails(Map<String, String> ans) {
+  double sum = 0.0;
+  double wSum = 0.0;
+  for (final k in exposureKeys) {
+    if (!questionParams.containsKey(k)) continue;
+    final weight = questionParams[k]!['weight'] as double;
+    wSum += weight;
+    sum += _calcFor(k, ans);
+  }
+  final score = wSum == 0 ? 0.0 : sum / wSum;
+  return {'sum': sum, 'weight': wSum, 'score': score};
+}
+
 double? computeFinalValueForInput(String key, String input) {
   double? val = double.tryParse(input);
   if (val == null) {

--- a/lib/presentation/screens/home_screen.dart
+++ b/lib/presentation/screens/home_screen.dart
@@ -780,6 +780,9 @@ class _HomeScreenState extends State<HomeScreen> {
 
     final vulnVal = computeVulnerabilityScore(st.answers);
     final expVal = computeExposureScore(st.answers);
+    final expDetails = computeExposureDetails(st.answers);
+    print(
+        'Exposure details -> sum: ${expDetails['sum']!.toStringAsFixed(2)}, weight: ${expDetails['weight']!.toStringAsFixed(2)}, score: ${expDetails['score']!.toStringAsFixed(2)}');
     String vulnerabilityScore = vulnVal.toStringAsFixed(2);
     String exposureScore = expVal.toStringAsFixed(2);
     String getTotalScore = asFixed(vulnerabilityScore).toString() + asFixed(exposureScore);


### PR DESCRIPTION
## Summary
- compute exposure details including sum, weight, and score
- log exposure details when generating report

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68808048e214833181b13ee881fc2ef1