### PR TITLE
Add exposure detail logging

### DIFF
--- a/lib/logic/score_calculate/question_weight.dart
+++ b/lib/logic/score_calculate/question_weight.dart
@@ -488,8 +488,31 @@ double computeScore(Map<String, String> ans, Set<String> keys) {
 double computeVulnerabilityScore(Map<String, String> ans) =>
     computeScore(ans, vulnerabilityKeys);
 
-double computeExposureScore(Map<String, String> ans) =>
-    computeScore(ans, exposureKeys);
+const double _exposureTotalWeight = 54.10716636;
+
+double computeExposureScore(Map<String, String> ans) {
+  final details = computeExposureDetails(ans);
+  return details['score'] ?? 0.0;
+}
+
+/// Returns a map containing the raw sum of weighted exposure values,
+/// the total weight of all exposure questions and the final exposure
+/// score (sum divided by total weight).
+Map<String, double> computeExposureDetails(Map<String, String> ans) {
+  double sum = 0.0;
+  for (final k in exposureKeys) {
+    if (!questionParams.containsKey(k)) continue;
+    sum += _calcFor(k, ans);
+  }
+  final score = _exposureTotalWeight == 0
+      ? 0.0
+      : sum / _exposureTotalWeight;
+  return {
+    'sum': sum,
+    'weight': _exposureTotalWeight,
+    'score': score,
+  };
+}
 
 double? computeFinalValueForInput(String key, String input) {
   double? val = double.tryParse(input);

--- a/lib/presentation/screens/home_screen.dart
+++ b/lib/presentation/screens/home_screen.dart
@@ -780,6 +780,9 @@ class _HomeScreenState extends State<HomeScreen> {
 
     final vulnVal = computeVulnerabilityScore(st.answers);
     final expVal = computeExposureScore(st.answers);
+    final expDetails = computeExposureDetails(st.answers);
+    print(
+        'Exposure details -> sum: ${expDetails['sum']!.toStringAsFixed(2)}, weight: ${expDetails['weight']!.toStringAsFixed(2)}, score: ${expDetails['score']!.toStringAsFixed(2)}');
     String vulnerabilityScore = vulnVal.toStringAsFixed(2);
     String exposureScore = expVal.toStringAsFixed(2);
     String getTotalScore = asFixed(vulnerabilityScore).toString() + asFixed(exposureScore);


### PR DESCRIPTION
## Summary
- compute exposure details including sum, constant weight, and score
- log exposure details when generating report
- weight for exposure fixed at 54.10716636

## Testing
- `dart format lib/logic/score_calculate/question_weight.dart lib/presentation/screens/home_screen.dart > /tmp/format.log && tail -n 20 /tmp/format.log` *(fails: command not found)*
- `flutter format lib/logic/score_calculate/question_weight.dart lib/presentation/screens/home_screen.dart > /tmp/format.log && tail -n 20 /tmp/format.log` *(fails: command not found)*
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68808048e214833181b13ee881fc2ef1