### PR TITLE
Add livestock totals to exposure calculation

### DIFF
--- a/lib/logic/score_calculate/question_weight.dart
+++ b/lib/logic/score_calculate/question_weight.dart
@@ -488,8 +488,53 @@ double computeScore(Map<String, String> ans, Set<String> keys) {
 double computeVulnerabilityScore(Map<String, String> ans) =>
     computeScore(ans, vulnerabilityKeys);
 
-double computeExposureScore(Map<String, String> ans) =>
-    computeScore(ans, exposureKeys);
+const double _exposureTotalWeight = 54.10716636;
+
+double computeExposureScore(Map<String, String> ans) {
+  final details = computeExposureDetails(ans);
+  return details['score'] ?? 0.0;
+}
+
+/// Returns a map containing the raw sum of weighted exposure values,
+/// the total weight of all exposure questions and the final exposure
+/// score (sum divided by total weight).
+Map<String, double> computeExposureDetails(Map<String, String> ans) {
+  double sum = 0.0;
+  for (final k in exposureKeys) {
+    if (!questionParams.containsKey(k)) continue;
+    sum += _calcFor(k, ans);
+  }
+  // Add aggregated exposure values derived from livestock questions
+  sum += _aggregateExposure({
+    '18.7', '18.8', '18.9', '18.10', '18.11', '18.12'
+  }, 7, 1.620113125, ans);
+  sum += _aggregateExposure({
+    '18.1', '18.2', '18.3', '18.4', '18.5', '18.6'
+  }, 8, 2.189443127, ans);
+  sum += _aggregateExposure({
+    '18.13', '18.14', '18.15', '18.16', '18.17', '18.18'
+  }, 8, 3.712540828, ans);
+  final score = _exposureTotalWeight == 0
+      ? 0.0
+      : sum / _exposureTotalWeight;
+  return {
+    'sum': sum,
+    'weight': _exposureTotalWeight,
+    'score': score,
+  };
+}
+
+double _aggregateExposure(Set<String> keys, double max, double weight,
+    Map<String, String> ans) {
+  double input = 0.0;
+  for (final k in keys) {
+    input += double.tryParse(ans[k] ?? '') ?? 0.0;
+  }
+  double value = ((max - input) / max) * weight;
+  if (value > weight) value = weight;
+  if (value < 0) value = 0;
+  return value;
+}
 
 double? computeFinalValueForInput(String key, String input) {
   double? val = double.tryParse(input);

--- a/lib/presentation/screens/home_screen.dart
+++ b/lib/presentation/screens/home_screen.dart
@@ -780,6 +780,9 @@ class _HomeScreenState extends State<HomeScreen> {
 
     final vulnVal = computeVulnerabilityScore(st.answers);
     final expVal = computeExposureScore(st.answers);
+    final expDetails = computeExposureDetails(st.answers);
+    print(
+        'Exposure details -> sum: ${expDetails['sum']!.toStringAsFixed(2)}, weight: ${expDetails['weight']!.toStringAsFixed(2)}, score: ${expDetails['score']!.toStringAsFixed(2)}');
     String vulnerabilityScore = vulnVal.toStringAsFixed(2);
     String exposureScore = expVal.toStringAsFixed(2);
     String getTotalScore = asFixed(vulnerabilityScore).toString() + asFixed(exposureScore);


### PR DESCRIPTION
## Summary
- extend exposure computations by aggregating livestock items
- add `_aggregateExposure` helper for computing sub-totals

## Testing
- `dart format lib/logic/score_calculate/question_weight.dart lib/presentation/screens/home_screen.dart > /tmp/format.log && tail -n 20 /tmp/format.log` *(fails: command not found)*
- `flutter format lib/logic/score_calculate/question_weight.dart lib/presentation/screens/home_screen.dart > /tmp/format.log && tail -n 20 /tmp/format.log` *(fails: command not found)*
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68808048e214833181b13ee881fc2ef1