### PR TITLE
Add debug list of exposure values

### DIFF
--- a/lib/presentation/screens/home_screen.dart
+++ b/lib/presentation/screens/home_screen.dart
@@ -780,6 +780,14 @@ class _HomeScreenState extends State<HomeScreen> {
 
     final vulnVal = computeVulnerabilityScore(st.answers);
     final expVal = computeExposureScore(st.answers);
+    final expDetails = computeExposureDetails(st.answers);
+    final valMap = expDetails['values'] as Map<String, double>;
+    final valuesStr = valMap.entries
+        .map((e) => '${e.key}:${e.value}')
+        .join(' + ');
+    print('Exposure values -> $valuesStr');
+    print(
+        'Exposure details -> sum: ${expDetails['sum']!.toStringAsFixed(2)}, weight: ${expDetails['weight']!.toStringAsFixed(2)}, score: ${expDetails['score']!.toStringAsFixed(2)}');
     String vulnerabilityScore = vulnVal.toStringAsFixed(2);
     String exposureScore = expVal.toStringAsFixed(2);
     String getTotalScore = asFixed(vulnerabilityScore).toString() + asFixed(exposureScore);


### PR DESCRIPTION
## Summary
- capture each exposure question's weighted value with labels in `computeExposureDetails`
- print the values with question labels when generating reports

## Testing
- `dart format lib/logic/score_calculate/question_weight.dart lib/presentation/screens/home_screen.dart > /tmp/format.log && tail -n 20 /tmp/format.log` *(fails: command not found)*
- `flutter format lib/logic/score_calculate/question_weight.dart lib/presentation/screens/home_screen.dart > /tmp/format.log && tail -n 20 /tmp/format.log` *(fails: command not found)*
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68808048e214833181b13ee881fc2ef1