### PR TITLE
Center overlay in gauge widget

### DIFF
--- a/lib/presentation/screens/home_screen.dart
+++ b/lib/presentation/screens/home_screen.dart
@@ -735,7 +735,7 @@ class _HomeScreenState extends State<HomeScreen> {
             ),
             pw.Positioned(
               left: 0,
-              right: 10,
+              right: 0,
               top: height * 0.33,
               child: pw.Column(
                 mainAxisSize: pw.MainAxisSize.min,


### PR DESCRIPTION
## Summary
- adjust `gaugeWithOverlay` to keep date and score perfectly centered

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68811205898083319d0d2bff658446a5