### PR TITLE
Center overlay in gauge widget

### DIFF
--- a/lib/presentation/screens/home_screen.dart
+++ b/lib/presentation/screens/home_screen.dart
@@ -652,6 +652,9 @@ class _HomeScreenState extends State<HomeScreen> {
     final pointerArrowImage = pw.MemoryImage(
       (await rootBundle.load('assets/images/score_arrow.png')).buffer.asUint8List(),
     );
+    final gaugePointerImage = pw.MemoryImage(
+      (await rootBundle.load('assets/images/pointer.png')).buffer.asUint8List(),
+    );
     final gaugeImage = pw.MemoryImage(
       (await rootBundle.load('assets/images/socio_gauge.png')).buffer.asUint8List(),
     );
@@ -713,12 +716,15 @@ class _HomeScreenState extends State<HomeScreen> {
       required String dateText,
       required double score,
       required pw.MemoryImage gaugeImage,
+      required pw.MemoryImage pointerImage,
       double width = 520,
       double height = 220,
+      double pointerSize = 20,
     }) {
       // Adjust these to match your PNG dimensions and overlay requirements
       final gaugeCenter = Offset(width / 2, height - 52);
       final arcRadius = width * 0.38; // adjust for best pointer fit
+      final pointerAngle = pi + value * pi;
       final pointerPos = _calcPointer(value, gaugeCenter.dx, gaugeCenter.dy, arcRadius);
 
       return pw.Container(
@@ -735,7 +741,7 @@ class _HomeScreenState extends State<HomeScreen> {
             ),
             pw.Positioned(
               left: 0,
-              right: 10,
+              right: 0,
               top: height * 0.33,
               child: pw.Column(
                 mainAxisSize: pw.MainAxisSize.min,
@@ -763,15 +769,15 @@ class _HomeScreenState extends State<HomeScreen> {
               ),
             ),
             pw.Positioned(
-              left: pointerPos.dx - 10,
-              top: pointerPos.dy - 10,
-              child: pw.Container(
-                width: 20,
-                height: 20,
-                decoration: pw.BoxDecoration(
-                  color: PdfColors.white,
-                  shape: pw.BoxShape.circle,
-                  border: pw.Border.all(color: PdfColors.black, width: 2),
+              left: pointerPos.dx - pointerSize / 2,
+              top: pointerPos.dy - pointerSize / 2,
+              child: pw.Transform.rotate(
+                angle: pointerAngle,
+                alignment: pw.Alignment.center,
+                child: pw.Image(
+                  pointerImage,
+                  width: pointerSize,
+                  height: pointerSize,
                 ),
               ),
             ),
@@ -995,6 +1001,7 @@ class _HomeScreenState extends State<HomeScreen> {
                           dateText: DateFormat('dd MMM yyyy').format(DateTime.now()),
                           score: double.tryParse(riskScore) ?? 0.0,
                           gaugeImage: rainbowGaugeImage,
+                          pointerImage: gaugePointerImage,
                           width: 520,
                           height: 220,
                         ),


### PR DESCRIPTION
## Summary
- load pointer.png for gauge overlay
- use pointer image in `gaugeWithOverlay`
- pass pointer to `gaugeWithOverlay`
- rotate and center the pointer overlay

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68811205898083319d0d2bff658446a5