### PR TITLE
Enhance vulnerability logging

### DIFF
--- a/lib/logic/score_calculate/question_weight.dart
+++ b/lib/logic/score_calculate/question_weight.dart
@@ -768,3 +768,92 @@ double? computeFinalValueForInput(String key, String input) {
   }
   return 0.0;
 }
+
+// --- Aggregated socio-climatic functions ---
+
+/// Question keys used for computing perception towards climate change (Q45).
+const List<String> _perceptionKeys = [
+  '44.1',
+  '44.2',
+  '44.3',
+  '44.4',
+  '44.5',
+  '44.6',
+  '44.7',
+  '44.8',
+  '44.9',
+  '44.10',
+  '44.11',
+  '44.12',
+  '44.13',
+  '44.14',
+  '44.15',
+  '44.16',
+];
+
+/// Question keys used for computing awareness towards climate change (Q46).
+const List<String> _awarenessKeys = [
+  '45.1',
+  '45.2',
+  '45.3',
+  '45.4',
+  '45.5',
+  '45.6',
+  '45.7',
+];
+
+/// Question keys used for computing preparedness towards climate change (Q47).
+const List<String> _preparednessKeys = [
+  '46.1',
+  '46.2',
+  '46.3',
+  '46.4',
+  '46.5',
+  '46.6',
+  '46.7',
+  '46.8',
+  '46.9',
+  '46.10',
+  '46.11',
+  '46.12',
+  '46.13',
+  '46.14',
+  '46.15',
+  '46.16',
+];
+
+/// Compute the accepted value for perception towards climate change (Q45).
+double computePerceptionAggregate(Map<String, String> ans) {
+  double sum = 0.0;
+  for (final key in _perceptionKeys) {
+    sum += double.tryParse(ans[key] ?? '0') ?? 0.0;
+  }
+  double val = ((45 - sum) / 45) * 3.259157652;
+  if (val > 3.259157652) val = 3.259157652;
+  if (val < 0) val = 0;
+  return val;
+}
+
+/// Compute the accepted value for awareness towards climate change (Q46).
+double computeAwarenessAggregate(Map<String, String> ans) {
+  double sum = 0.0;
+  for (final key in _awarenessKeys) {
+    sum += double.tryParse(ans[key] ?? '0') ?? 0.0;
+  }
+  double val = ((36 - sum) / 36) * 2.336440171;
+  if (val > 2.336440171) val = 2.336440171;
+  if (val < 0) val = 0;
+  return val;
+}
+
+/// Compute the accepted value for preparedness towards climate change (Q47).
+double computePreparednessAggregate(Map<String, String> ans) {
+  double sum = 0.0;
+  for (final key in _preparednessKeys) {
+    sum += double.tryParse(ans[key] ?? '0') ?? 0.0;
+  }
+  double val = ((15 - sum) / 14) * 5.852537611;
+  if (val > 5.852537611) val = 5.852537611;
+  if (val < 0) val = 0;
+  return val;
+}

--- a/lib/presentation/utils/report_generator.dart
+++ b/lib/presentation/utils/report_generator.dart
@@ -138,6 +138,37 @@ class ReportGenerator {
     final formattedAnswers = answers.map((k, v) => MapEntry(k, v.toString()));
     final vulnDetails = computeVulnerabilityDetails(formattedAnswers);
     final vulnVal = vulnDetails['score'] as double;
+
+    // Log vulnerability values used in score calculation with question numbers
+    final vulnValues = Map<String, double>.from(
+        vulnDetails['values'] as Map<String, dynamic>);
+    final vulnSum = vulnDetails['sum'] as double;
+    final vulnWeight = vulnDetails['weight'] as double;
+    int _idx = 1;
+    print('Vulnerability calculation details:');
+    vulnValues.forEach((label, value) {
+      print('$_idx. $label: ${value.toStringAsFixed(2)}');
+      _idx++;
+    });
+
+    // Additional question values that contribute to vulnerability
+    const otherKeys = ['5', '3', '11', '16', '17', '35', '37', '38'];
+    for (final k in otherKeys) {
+      final raw = answers[k]?.toString() ?? '';
+      final v = computeFinalValueForInput(k, raw) ?? 0.0;
+      print('$_idx. Q$k: ${v.toStringAsFixed(3)}');
+      _idx++;
+    }
+    final q45 = computePerceptionAggregate(formattedAnswers);
+    final q46 = computeAwarenessAggregate(formattedAnswers);
+    final q47 = computePreparednessAggregate(formattedAnswers);
+    print('$_idx. Q45: ${q45.toStringAsFixed(3)}');
+    _idx++;
+    print('$_idx. Q46: ${q46.toStringAsFixed(3)}');
+    _idx++;
+    print('$_idx. Q47: ${q47.toStringAsFixed(3)}');
+    print('Vulnerability sum: ${vulnSum.toStringAsFixed(2)}, weight: ${vulnWeight.toStringAsFixed(2)}');
+
     final expDetails = computeExposureDetails(formattedAnswers);
     final expVal = expDetails['score'] as double;
 


### PR DESCRIPTION
## Summary
- print each vulnerability value with numbering
- also list additional question values and aggregates Q45-Q47
- output vulnerability sum and weight for clarity

## Testing
- `dart format lib/logic/score_calculate/question_weight.dart lib/presentation/utils/report_generator.dart` *(fails: command not found)*
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6881f57e936c8331b5e65a0796fce84d