### PR TITLE
Fix vulnerability sum calculation

### DIFF
--- a/lib/logic/score_calculate/question_weight.dart
+++ b/lib/logic/score_calculate/question_weight.dart
@@ -389,7 +389,37 @@ int mapHouseType(String val) {
 
 // Keys for vulnerability and exposure questions used in score calculation
 final Set<String> vulnerabilityKeys = {
-  '2', '13', '15', '18', '18.1', '18.8', '18.14', '28', '26'
+  '2',
+  '13',
+  '15',
+  '18',
+  '18.1',
+  '18.8',
+  '18.14',
+  '28',
+  '26',
+  '5',
+  '3',
+  '11',
+  '16',
+  '17',
+  '35',
+  '37',
+  '38',
+  '13.1',
+  '27',
+  '31',
+  '32',
+  '33',
+  '39',
+  '40',
+  '41',
+  '42',
+  '43',
+  '44',
+  '45',
+  '46',
+  '47',
 };
 
 final Set<String> exposureKeys = {
@@ -495,7 +525,7 @@ double computeVulnerabilityScore(Map<String, String> ans) {
 
 /// Total weight of all vulnerability questions. This value is treated
 /// as static for now.
-const double _vulnerabilityTotalWeight = 123.06;
+const double _vulnerabilityTotalWeight = 127.59887142354158;
 
 /// Order in which vulnerability values should be listed when returning
 /// details for debugging. The keys map to the internal question keys
@@ -510,6 +540,28 @@ const List<String> _orderedVulnerabilityKeys = [
   '18.14',
   '28',
   '26',
+  '5',
+  '3',
+  '11',
+  '16',
+  '17',
+  '35',
+  '37',
+  '38',
+  '13.1',
+  '27',
+  '31',
+  '32',
+  '33',
+  '39',
+  '40',
+  '41',
+  '42',
+  '43',
+  '44',
+  '45',
+  '46',
+  '47',
 ];
 
 /// Labels corresponding to [_orderedVulnerabilityKeys] so callers can
@@ -524,6 +576,28 @@ const Map<String, String> _vulnerabilityLabels = {
   '18.14': 'Q18.14',
   '28': 'Q28',
   '26': 'Q26',
+  '5': 'Q5',
+  '3': 'Q3',
+  '11': 'Q11',
+  '16': 'Q16',
+  '17': 'Q17',
+  '35': 'Q35',
+  '37': 'Q37',
+  '38': 'Q38',
+  '13.1': 'Q13.1',
+  '27': 'Q27',
+  '31': 'Q31',
+  '32': 'Q32',
+  '33': 'Q33',
+  '39': 'Q39',
+  '40': 'Q40',
+  '41': 'Q41',
+  '42': 'Q42',
+  '43': 'Q43',
+  '44': 'Q44',
+  '45': 'Q45',
+  '46': 'Q46',
+  '47': 'Q47',
 };
 
 const double _exposureTotalWeight = 54.10716636;
@@ -669,7 +743,16 @@ Map<String, dynamic> computeVulnerabilityDetails(Map<String, String> ans) {
   double sum = 0.0;
   final Map<String, double> values = {};
   for (final k in _orderedVulnerabilityKeys) {
-    final v = _calcFor(k, ans);
+    double v;
+    if (k == '45') {
+      v = computePerceptionAggregate(ans);
+    } else if (k == '46') {
+      v = computeAwarenessAggregate(ans);
+    } else if (k == '47') {
+      v = computePreparednessAggregate(ans);
+    } else {
+      v = _calcFor(k, ans);
+    }
     values[_vulnerabilityLabels[k] ?? k] = v;
     sum += v;
   }
@@ -767,4 +850,93 @@ double? computeFinalValueForInput(String key, String input) {
     return unweighted * weight;
   }
   return 0.0;
+}
+
+// --- Aggregated socio-climatic functions ---
+
+/// Question keys used for computing perception towards climate change (Q45).
+const List<String> _perceptionKeys = [
+  '44.1',
+  '44.2',
+  '44.3',
+  '44.4',
+  '44.5',
+  '44.6',
+  '44.7',
+  '44.8',
+  '44.9',
+  '44.10',
+  '44.11',
+  '44.12',
+  '44.13',
+  '44.14',
+  '44.15',
+  '44.16',
+];
+
+/// Question keys used for computing awareness towards climate change (Q46).
+const List<String> _awarenessKeys = [
+  '45.1',
+  '45.2',
+  '45.3',
+  '45.4',
+  '45.5',
+  '45.6',
+  '45.7',
+];
+
+/// Question keys used for computing preparedness towards climate change (Q47).
+const List<String> _preparednessKeys = [
+  '46.1',
+  '46.2',
+  '46.3',
+  '46.4',
+  '46.5',
+  '46.6',
+  '46.7',
+  '46.8',
+  '46.9',
+  '46.10',
+  '46.11',
+  '46.12',
+  '46.13',
+  '46.14',
+  '46.15',
+  '46.16',
+];
+
+/// Compute the accepted value for perception towards climate change (Q45).
+double computePerceptionAggregate(Map<String, String> ans) {
+  double sum = 0.0;
+  for (final key in _perceptionKeys) {
+    sum += double.tryParse(ans[key] ?? '0') ?? 0.0;
+  }
+  double val = ((45 - sum) / 45) * 3.259157652;
+  if (val > 3.259157652) val = 3.259157652;
+  if (val < 0) val = 0;
+  return val;
+}
+
+/// Compute the accepted value for awareness towards climate change (Q46).
+double computeAwarenessAggregate(Map<String, String> ans) {
+  double sum = 0.0;
+  for (final key in _awarenessKeys) {
+    sum += double.tryParse(ans[key] ?? '0') ?? 0.0;
+  }
+  double val = ((36 - sum) / 36) * 2.336440171;
+  if (val > 2.336440171) val = 2.336440171;
+  if (val < 0) val = 0;
+  return val;
+}
+
+/// Compute the accepted value for preparedness towards climate change (Q47).
+double computePreparednessAggregate(Map<String, String> ans) {
+  double sum = 0.0;
+  for (final key in _preparednessKeys) {
+    sum += double.tryParse(ans[key] ?? '0') ?? 0.0;
+  }
+  double val = ((15 - sum) / 14) * 5.852537611;
+  if (val > 5.852537611) val = 5.852537611;
+  if (val < 0) val = 0;
+  return val;
 }

--- a/lib/presentation/screens/home_screen.dart
+++ b/lib/presentation/screens/home_screen.dart
@@ -3302,6 +3302,12 @@ class _AgCardState extends State<_AgCard> {
     if (v == '13.1' || v == '13.2' || v == '13.3') {
       _landAnswers[v] = input;
 
+      // Save the raw value for each sub-question so that the report
+      // generator can display accepted values for Q13.1, Q13.2 and
+      // Q13.3 individually.
+      bloc.add(SaveAnswerEvent(v, input));
+      widget.onSave?.call(v, input);
+
       final owned = double.tryParse(_landAnswers['13.1'] ?? '') ?? 0.0;
       final leasedIn = double.tryParse(_landAnswers['13.2'] ?? '') ?? 0.0;
       final leasedOut = double.tryParse(_landAnswers['13.3'] ?? '') ?? 0.0;

--- a/lib/presentation/utils/report_generator.dart
+++ b/lib/presentation/utils/report_generator.dart
@@ -138,6 +138,46 @@ class ReportGenerator {
     final formattedAnswers = answers.map((k, v) => MapEntry(k, v.toString()));
     final vulnDetails = computeVulnerabilityDetails(formattedAnswers);
     final vulnVal = vulnDetails['score'] as double;
+
+    // Log vulnerability values used in score calculation with question numbers
+    final vulnValues = Map<String, double>.from(
+        vulnDetails['values'] as Map<String, dynamic>);
+    final vulnSum = vulnDetails['sum'] as double;
+    final vulnWeight = vulnDetails['weight'] as double;
+    int _idx = 1;
+    print('Vulnerability calculation details:');
+    vulnValues.forEach((label, value) {
+      // Print raw accepted value without rounding so users can see the
+      // precise contribution from each question.
+      print('$_idx. $label: $value');
+      _idx++;
+    });
+
+    // Additional accepted values for the key vulnerability questions
+    const selectedLabels = [
+      'Q5',
+      'Q3',
+      'Q11',
+      'Q16',
+      'Q17',
+      'Q35',
+      'Q37',
+      'Q38',
+      'Q45',
+      'Q46',
+      'Q47',
+    ];
+    print('Accepted values for selected questions:');
+    for (final label in selectedLabels) {
+      final value = vulnValues[label];
+      if (value != null) {
+        print('$label: $value');
+      }
+    }
+
+    // Vulnerability sum and weight
+    print('Vulnerability sum: $vulnSum, weight: $vulnWeight');
+
     final expDetails = computeExposureDetails(formattedAnswers);
     final expVal = expDetails['score'] as double;
 


### PR DESCRIPTION
## Summary
- include all requested questions including Q26 and aggregated Q45–Q47 in vulnerability sets
- recompute total vulnerability weight
- update report log to print values directly from the vulnerability details
- print the selected questions' accepted values in the report logs
- ensure Q13.1 and related sub-questions are saved individually

## Testing
- `dart format lib/logic/score_calculate/question_weight.dart lib/presentation/utils/report_generator.dart lib/presentation/screens/home_screen.dart` *(fails: command not found)*
- `flutter test` *(fails: command not found)*


------
https://chatgpt.com/codex/tasks/task_e_6881f57e936c8331b5e65a0796fce84d