### PR TITLE
Add final risk computation to PDF report

### DIFF
--- a/lib/presentation/utils/report_generator.dart
+++ b/lib/presentation/utils/report_generator.dart
@@ -175,6 +175,10 @@ class ReportGenerator {
     String exposureScore = expVal.toStringAsFixed(2);
     String riskScore = asFixed(st.answers['riskScore']);
 
+    // Calculate the final risk score using the standard methodology.
+    double finalRisk = vulnVal * expVal * hazardVal;
+    String finalRiskScore = finalRisk.toStringAsFixed(4);
+
     pdf.addPage(
       pw.Page(
         pageFormat: PdfPageFormat.a4,
@@ -375,6 +379,14 @@ class ReportGenerator {
                             ),
                           ),
                         ],
+                      ),
+                    ),
+                    pw.SizedBox(height: 6),
+                    pw.Text(
+                      'Final Risk Value: $finalRiskScore',
+                      style: pw.TextStyle(
+                        fontSize: 16,
+                        fontWeight: pw.FontWeight.bold,
                       ),
                     ),
                   ],


### PR DESCRIPTION
## Summary
- compute final risk based on vulnerability, exposure and hazard
- display Final Risk Value below the disclaimer in the generated PDF

## Testing
- `git status --short`
- `git diff --staged`

Codex couldn't run certain commands due to environment limitations. Consider configuring a setup script or internet access in your Codex environment to install dependencies.

------
https://chatgpt.com/codex/tasks/task_e_68884c2dd7088331ba0c92ee406cf97b