### PR TITLE
Handle location fetch errors

### DIFF
--- a/lib/data/services/location_service.dart
+++ b/lib/data/services/location_service.dart
@@ -209,11 +209,16 @@ class LocationService {
   List<String>? cachedDistricts(String state) => _distCache[state];
 
   Future<void> prefetchStates() async {
-    final r = await _dio.get('/admin/location/states');
-    final raw = (r.data?['states'] as List<dynamic>);
-    _states = raw.map((e) => e['state_name'] as String).toList()..sort();
-    for (var e in raw) {
-      _stateId[e['state_name']] = e['state_id'];
+    try {
+      final r = await _dio.get('/admin/location/states');
+      final raw = (r.data?['states'] as List<dynamic>);
+      _states = raw.map((e) => e['state_name'] as String).toList()..sort();
+      for (var e in raw) {
+        _stateId[e['state_name']] = e['state_id'];
+      }
+    } catch (_) {
+      // Ensure lists are initialized even if the request fails
+      _states = [];
     }
   }
 

--- a/lib/data/services/location_state.dart
+++ b/lib/data/services/location_state.dart
@@ -16,7 +16,11 @@ class LocationCubit extends Cubit<LocationState> {
   final _svc = LocationService();
 
   Future<void> _init() async {
-    await _svc.prefetchStates();
+    try {
+      await _svc.prefetchStates();
+    } catch (_) {
+      // ignore errors during initialization
+    }
     emit(LocReady());
   }
 


### PR DESCRIPTION
## Summary
- protect `prefetchStates` against network errors
- ignore exceptions in `LocationCubit` initialization

## Testing
- `flutter --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_688c52eb9418833196edf7ad78facfc2