### PR TITLE
Fix stuck loader when states list fails to load

### DIFF
--- a/lib/presentation/screens/home_screen.dart
+++ b/lib/presentation/screens/home_screen.dart
@@ -450,10 +450,12 @@ class _HomeScreenState extends State<HomeScreen> {
       final data = json.decode(jsonString);
       final storedState = data['stateName'];
       final storedDistrict = data['district'];
-      while (loc.states.isEmpty) {
-        await Future.delayed(const Duration(milliseconds: 40));
+      int tries = 0;
+      while (loc.states.isEmpty && tries < 50) {
+        await Future.delayed(const Duration(milliseconds: 100));
+        tries++;
       }
-      if (storedState != null) {
+      if (storedState != null && loc.states.isNotEmpty) {
         await loc.districts(storedState);
       }
 


### PR DESCRIPTION
## Summary
- prevent `_loadLocalAnswers` from waiting forever when state list fails to load

## Testing
- `flutter --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_688c5524e31c8331ae5629fa020b28c0