### PR TITLE
Fix report generation permissions

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -4,6 +4,7 @@ import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:flutter_downloader/flutter_downloader.dart';
 import 'package:flutter_screenutil/flutter_screenutil.dart';
 import 'package:permission_handler/permission_handler.dart';
+import 'dart:io' show Platform;
 
 import 'config/router/go_router.dart';
 import 'data/services/location_state.dart';
@@ -27,7 +28,15 @@ Future<void> main() async {
     ignoreSsl: true,
   );
 
-  await Permission.storage.request();
+  if (Platform.isAndroid) {
+    var status = await Permission.manageExternalStorage.status;
+    if (!status.isGranted) {
+      status = await Permission.manageExternalStorage.request();
+    }
+    if (!status.isGranted) {
+      await Permission.storage.request();
+    }
+  }
 
   final locCubit = LocationCubit();
 

--- a/lib/presentation/screens/home_screen.dart
+++ b/lib/presentation/screens/home_screen.dart
@@ -10,6 +10,7 @@ import 'package:go_router/go_router.dart';
 import 'package:ndri_dairy_risk/presentation/screens/preview_answers_screen.dart';
 import 'package:ndri_dairy_risk/presentation/widgets/app_text.dart';
 import 'package:open_file/open_file.dart';
+import 'package:permission_handler/permission_handler.dart';
 import 'package:shared_preferences/shared_preferences.dart';
 import '../../config/app_colors.dart';
 import '../../config/app_strings.dart';
@@ -207,12 +208,13 @@ class _HomeScreenState extends State<HomeScreen> {
 
   Future<void> _initPermissions() async {
     if (!Platform.isAndroid) return;
-
-/*    await Permission.storage.request();
-    if (await Permission.manageExternalStorage.isDenied) {
-
-      await Permission.manageExternalStorage.request();
-    }*/
+    var status = await Permission.manageExternalStorage.status;
+    if (!status.isGranted) {
+      status = await Permission.manageExternalStorage.request();
+    }
+    if (!status.isGranted) {
+      await Permission.storage.request();
+    }
   }
 
   Future<void> _initNotifications() async {


### PR DESCRIPTION
## Summary
- request storage and manage external storage permissions properly
- add permission handling in report generation screen

## Testing
- `flutter --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_688c59abde348331a43a5ebbe9200440