### PR TITLE
Print exposure values when generating report

### DIFF
--- a/lib/presentation/utils/report_generator.dart
+++ b/lib/presentation/utils/report_generator.dart
@@ -4,6 +4,7 @@ import 'dart:ui';
 
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
+import 'package:flutter/foundation.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:flutter_local_notifications/flutter_local_notifications.dart';
 import 'package:intl/intl.dart';
@@ -174,6 +175,13 @@ class ReportGenerator {
     final double vulnVal = vulnDetails['score'] as double;
     final double expVal = expDetails['score'] as double;
     final double hazardVal = LocationService().hazardFor(district ?? '');
+
+    final Map<String, double> exposureValues =
+        Map<String, double>.from(expDetails['values'] as Map);
+    for (final entry in exposureValues.entries) {
+      debugPrint('Exposure ${entry.key}: ${entry.value.toStringAsFixed(2)}');
+    }
+    debugPrint('Total Exposure Score: ${expVal.toStringAsFixed(2)}');
 
     final String hazardScore = hazardVal.toStringAsFixed(2);
     final String vulnerabilityScore = vulnVal.toStringAsFixed(2);


### PR DESCRIPTION
## Summary
- log exposure question values and total exposure score when generating report
- add foundation import for debug printing

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a0d320c69883318960f0c4e0c2dd26