### PR TITLE
Increase exposure score precision

### DIFF
--- a/lib/presentation/utils/report_generator.dart
+++ b/lib/presentation/utils/report_generator.dart
@@ -179,13 +179,13 @@ class ReportGenerator {
     final Map<String, double> exposureValues =
         Map<String, double>.from(expDetails['values'] as Map);
     for (final entry in exposureValues.entries) {
-      debugPrint('Exposure ${entry.key}: ${entry.value.toStringAsFixed(2)}');
+      debugPrint('Exposure ${entry.key}: ${entry.value.toStringAsFixed(3)}');
     }
-    debugPrint('Total Exposure Score: ${expVal.toStringAsFixed(2)}');
+    debugPrint('Total Exposure Score: ${expVal.toStringAsFixed(3)}');
 
     final String hazardScore = hazardVal.toStringAsFixed(2);
     final String vulnerabilityScore = vulnVal.toStringAsFixed(2);
-    final String exposureScore = expVal.toStringAsFixed(2);
+    final String exposureScore = expVal.toStringAsFixed(3);
     final String riskScore = asFixed(st.answers['riskScore']);
 
     final double finalRisk = vulnVal * expVal * hazardVal;


### PR DESCRIPTION
## Summary
- show exposure component and total scores to three decimals for better accuracy

## Testing
- `flutter test` *(fails: command not found)*
- `dart test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a0d649c738833192b8f289e8ce6d55