### PR TITLE
Add question text and weight to exposure debug output

### DIFF
--- a/lib/logic/score_calculate/question_weight.dart
+++ b/lib/logic/score_calculate/question_weight.dart
@@ -628,7 +628,7 @@ const List<String> _orderedExposureKeys = [
 /// [questionParams]. Most exposure questions share the same key for
 /// both the answer and parameter lookup except question 29 which uses
 /// `29_exp` internally.
-const Map<String, String> _exposureParamKeys = {
+const Map<String, String> exposureParamKeys = {
   '7': '7_exp',
   '8': '8_exp',
   '6': '6_exp',
@@ -671,6 +671,13 @@ const Map<String, String> _exposureLabels = {
   'cu6': 'CU6',
 };
 
+/// Weights for aggregated exposure questions derived from livestock data.
+const Map<String, double> exposureAggregatedWeights = {
+  'BW6': 1.620113125,
+  'CI6': 2.189443127,
+  'CU6': 3.712540828,
+};
+
 /// Weights used for livestock unit calculations when aggregating
 /// exposure values from individual animal counts.
 const Map<String, double> _livestockWeights = {
@@ -711,17 +718,17 @@ Map<String, dynamic> computeExposureDetails(Map<String, String> ans) {
   /// Add aggregated exposure values derived from livestock questions
   final bw6 = _aggregateExposure({
     '18.7', '18.8', '18.9', '18.10', '18.11', '18.12'
-  }, 7, 1.620113125, ans, _livestockWeights);
+  }, 7, exposureAggregatedWeights['BW6']!, ans, _livestockWeights);
   values[_exposureLabels['bw6']!] = bw6;
   sum += bw6;
   final ci6 = _aggregateExposure({
     '18.1', '18.2', '18.3', '18.4', '18.5', '18.6'
-  }, 8, 2.189443127, ans, _livestockWeights);
+  }, 8, exposureAggregatedWeights['CI6']!, ans, _livestockWeights);
   values[_exposureLabels['ci6']!] = ci6;
   sum += ci6;
   final cu6 = _aggregateExposure({
     '18.13', '18.14', '18.15', '18.16', '18.17', '18.18'
-  }, 8, 3.712540828, ans, _livestockWeights);
+  }, 8, exposureAggregatedWeights['CU6']!, ans, _livestockWeights);
   values[_exposureLabels['cu6']!] = cu6;
   sum += cu6;
   final score = _exposureTotalWeight == 0 ? 0.0 : sum / _exposureTotalWeight;
@@ -780,7 +787,7 @@ double _aggregateExposure(Set<String> keys, double max, double weight,
 }
 
 double _calcExposure(String key, Map<String, String> ans) {
-  final paramKey = _exposureParamKeys[key] ?? key;
+  final paramKey = exposureParamKeys[key] ?? key;
   if (!questionParams.containsKey(paramKey)) return 0.0;
   String? raw = ans[key];
   double? input = double.tryParse(raw ?? '');

--- a/lib/presentation/utils/report_generator.dart
+++ b/lib/presentation/utils/report_generator.dart
@@ -13,6 +13,7 @@ import 'package:path_provider/path_provider.dart';
 import 'package:pdf/pdf.dart';
 import 'package:pdf/widgets.dart' as pw;
 
+import '../../data/repositories/question_repository.dart';
 import '../../data/services/location_service.dart';
 import '../../logic/risk_assessment/bloc/risk_assessment_bloc.dart';
 import '../../logic/risk_assessment/bloc/risk_assessment_state.dart';
@@ -178,9 +179,24 @@ class ReportGenerator {
 
     final Map<String, double> exposureValues =
         Map<String, double>.from(expDetails['values'] as Map);
+
+    // Map question numbers to their text for easier debugging output.
+    final questionMap = {
+      for (final q in QuestionRepository.getQuestions()) q.variableNumber: q.questionText
+    };
+
     for (final entry in exposureValues.entries) {
-      debugPrint('Exposure ${entry.key}: ${entry.value.toStringAsFixed(3)}');
+      final label = entry.key;
+      final qNum = label.startsWith('Q') ? label.substring(1) : label;
+      final paramKey = exposureParamKeys[qNum] ?? qNum;
+      final double? weight =
+          (questionParams[paramKey]?['weight'] as double?) ??
+              exposureAggregatedWeights[label];
+      final questionText = questionMap[qNum] ?? label;
+      debugPrint(
+          'Exposure $label: ${entry.value.toStringAsFixed(3)} | Question: $questionText | Weight: ${weight?.toStringAsFixed(3) ?? 'N/A'}');
     }
+
     debugPrint('Total Exposure Score: ${expVal.toStringAsFixed(3)}');
 
     final String hazardScore = hazardVal.toStringAsFixed(2);


### PR DESCRIPTION
## Summary
- expose exposure parameter keys and aggregated weights
- log exposure question text and weight alongside computed value for easier debugging

## Testing
- `flutter test` *(fails: command not found)*
- `apt-get update` *(fails: repositories not signed)*

------
https://chatgpt.com/codex/tasks/task_e_68a0d9cc815c833191a197fc79d19ac9