### PR TITLE
Log exposure and vulnerability values when downloading report

### DIFF
--- a/lib/presentation/utils/report_generator.dart
+++ b/lib/presentation/utils/report_generator.dart
@@ -97,6 +97,16 @@ class ReportGenerator {
     final vulnDetails = computeVulnerabilityDetails(formattedAnswers);
     final expDetails = computeExposureDetails(formattedAnswers);
 
+    debugPrint('Exposure question values:');
+    (expDetails['values'] as Map<String, double>)
+        .forEach((k, v) => debugPrint('$k: $v'));
+    debugPrint('Exposure sum: ${expDetails['sum']}');
+
+    debugPrint('Vulnerability question values:');
+    (vulnDetails['values'] as Map<String, double>)
+        .forEach((k, v) => debugPrint('$k: $v'));
+    debugPrint('Vulnerability sum: ${vulnDetails['sum']}');
+
     final double rawVuln = (vulnDetails['score'] as double?) ?? 0.0;
     final double rawExp = (expDetails['score'] as double?) ?? 0.0;
 
@@ -110,6 +120,9 @@ class ReportGenerator {
         _normalize(rawHazard, _hazMin, _hazMax));
     final double acceptedVulnerability = _clamp01(
         _normalize(rawVuln, _vulnMin, _vulnMax));
+
+    debugPrint('Accepted Exposure value: $acceptedExposure');
+    debugPrint('Accepted Vulnerability value: $acceptedVulnerability');
 
     // ==== 3) Status labels ====
     final String exposureStatus = _bandLabel(acceptedExposure);


### PR DESCRIPTION
## Summary
- Log per-question exposure values and sum when generating a report
- Log per-question vulnerability values and sum
- Print normalized exposure and vulnerability scores for debugging

## Testing
- `dart format lib/presentation/utils/report_generator.dart` *(fails: command not found)*
- `flutter test` *(fails: command not found)*


------
https://chatgpt.com/codex/tasks/task_e_68b69dd673e88331ae9c3431d930d916